### PR TITLE
Tmp file no longer created, with a few small details

### DIFF
--- a/the-streamliner.py
+++ b/the-streamliner.py
@@ -20,9 +20,9 @@ import argparse        # Allows the use of flags from the command line
 
 # You can clean up the help lines if you want
 parser = argparse.ArgumentParser(description='"The Streamliner" is a simple Python utility that allows users to target a particular webpage or text file and filter all of the email addresses that contained within it. This tool is especially useful when distilling large web directories, cluttered or poorly formatted email lists, or web pages with mailto: links into a txt or csv file.')
-parser.add_argument('--url', help='Provide the full URL to the target webpage that contains emails.', type=str) # url flag
-parser.add_argument('--file', help='Provide the local path to the file that contains emails.', type=str) # file flag
-parser.add_argument('--export', help='Type the name of the file you want to export (only .txt and .csv)', type=str) # export flag
+parser.add_argument('-u', '--url', help='Provide the full URL to the target webpage that contains emails.', type=str) # url flag
+parser.add_argument('-f', '--file', help='Provide the local path to the file that contains emails.', type=str) # file flag
+parser.add_argument('-e', '--export', help='Type the name of the file you want to export (only .txt and .csv)', type=str) # export flag
 
 args = parser.parse_args() # Allows you to call arguments using args.[argument]
 
@@ -48,9 +48,9 @@ web directories, cluttered or poorly formatted email lists, or web pages
 with mailto: links into a txt or csv file.
 
     Streamliner usage:
-    --url          Provide the full URL to the target webpage that contains emails.
-    --file         Provide the local path to the file that contains emails.
-    --export       Type the name of the file you want to export (only .txt and .csv)
+    -u, --url          Provide the full URL to the target webpage that contains emails.
+    -f, --file         Provide the local path to the file that contains emails.
+    -e, --export       Type the name of the file you want to export (only .txt and .csv)
 
     NOTE: For both the URL and the file, the path must end in a text-based
     file extention such as .html or .txt. The program will throw errors
@@ -64,7 +64,7 @@ with mailto: links into a txt or csv file.
 # If arguments were provided, run program
 else:
     # If user entered a URL as an argument
-    if args.url is not None:
+    if args.url:
         url = args.url
         # Store HTML into a tmp file. This is removed during cleanup. This is done using the urllib.request lib import
         urllib.request.urlretrieve(url, "site.tmp")
@@ -72,7 +72,7 @@ else:
         file_contents = open("site.tmp").read()
         # Cleanup and remove the .tmp file
         os.remove("site.tmp")
-    elif args.file is not None:
+    elif args.file:
         file_name = args.file
         # Store document text as var
         file_contents = open(file_name).read()
@@ -96,7 +96,7 @@ else:
     print("|======== A total of " + str(len(email_list)) + " email addresses were on this page ========|")
 
     # If the user opted to export the file
-    if args.export is not None:
+    if args.export:
         # Grab file name and the file type
         full_file_name = args.export
         file_type = args.export[-3:]

--- a/the-streamliner.py
+++ b/the-streamliner.py
@@ -14,9 +14,9 @@
 import re              # Allow the use of the findall() function
 import urllib.request  # Allow to grab web URLS and Website Content
 import csv             # Allow for the exporting to a csv file
-import os              # Allow the program to make and remove files
 import sys             # Allow to check if arguments are passed through
 import argparse        # Allows the use of flags from the command line
+import io              # Allows for text stream buffer
 
 # You can clean up the help lines if you want
 parser = argparse.ArgumentParser(description='"The Streamliner" is a simple Python utility that allows users to target a particular webpage or text file and filter all of the email addresses that contained within it. This tool is especially useful when distilling large web directories, cluttered or poorly formatted email lists, or web pages with mailto: links into a txt or csv file.')
@@ -66,12 +66,9 @@ else:
     # If user entered a URL as an argument
     if args.url:
         url = args.url
-        # Store HTML into a tmp file. This is removed during cleanup. This is done using the urllib.request lib import
-        urllib.request.urlretrieve(url, "site.tmp")
-        # Store all data from that file into a var using open()
-        file_contents = open("site.tmp").read()
-        # Cleanup and remove the .tmp file
-        os.remove("site.tmp")
+        u = urllib.request.urlopen(url, data=None)
+        file = io.TextIOWrapper(u, encoding='utf-8')
+        file_contents = file.read()
     elif args.file:
         file_name = args.file
         # Store document text as var
@@ -111,7 +108,7 @@ else:
             # Close the connection and disable editing
             writeOut.close()
             print("\n")
-            print("Your file has been exported as saved as " + full_file_name)
+            print("Your file has been exported as saved as " + full_file_name + " within current working directory.")
 
         # If csv is chosen, write it out
         elif file_type == "csv":


### PR DESCRIPTION
This uses the IO package to create a text stream in memory rather than creating a tmp file, saving time from having to the write copy text to a new file and then deleting afterwards.

Other changes include:
Added short argument flags.
Cleaned up some redundant code.
Made the export message clear.