### PR TITLE
v1.1.4 Fix for websites without '.html' and HTTP error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Streamliner v1.1.3
+# The Streamliner v1.1.4
 >"The Streamliner" is a simple Python utility that allows users to target a particular webpage or text file and filter all of the email addresses that contained within it. Written using Python 3, this tool is especially useful when distilling large web directories, cluttered or poorly formatted email lists, or web pages with mailto: links into a txt or csv file
 
 ### How to use:

--- a/changelog.md
+++ b/changelog.md
@@ -16,10 +16,14 @@ All notable changes to this project will be documented in this file. The format 
     [Security] in case of vulnerabilities.
 
 ## [Unreleased] - Upcoming Changes, Current Projects, and 'wish list' items
-* So, there is a 'bug' that isn't really a bug. Lots of websites like to dynamically create their content, and end in URLs like this: http://oregontrailschools.com/shs/administration/. Because it does not end with a .html it has no data to store, and also thinks that it's not a valid URL. We need to find a way to grab the HTML document that the URL leads to. Is that something in the URLlib? 
 * Since I am new to Python scripting, I am sure that I am overusing libraries, or that I was not very efficient. I would love a second pair of eyes to make this program and lightweight as possible
 * A big future idea would be to somehow spider an entire site and go looking for addresses. This would be a HUGE upgrade, but is also a much larger project that the current application scope. Version 2.0?
 * Are there any other file types that are good to export to? I was thinking about an easy to way to then use the exported file to import for something like a mass mailer or store in a DB.
+## [1.1.4] - 2018-04-05
+### Added
+- Error handling for HTTP errors, such as 404 - Page Not Found errors
+### Fixed
+- Pages without `.html` raising a `URLError` fixed
 ## [1.1.3] - 2018-04-04
 ### Added
 - Error handling. Added errors for:

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-    The Streamliner - v1.1.3
+    The Streamliner - v1.1.4
     Created by: Tobin Shields
     Other contributors: Trevor Warner, Jacob Bickle
 

--- a/the-streamliner.py
+++ b/the-streamliner.py
@@ -70,16 +70,34 @@ else:
     # If user entered a URL as an argument
     if args.url:
         url = args.url
+
+        # This is header information. It requests the website
+        # posing as Mozilla, and somehow it fixes the issue where
+        # you couldn't get websites that don't have '.html' on the end.
+        # But because of this, websites with invalid top level domain name
+        # pass through the error filters, but this shouldn't happen in regular use.
+        hdr = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11',
+               'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+               'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
+               'Accept-Encoding': 'none',
+               'Accept-Language': 'en-US,en;q=0.8',
+               'Connection': 'keep-alive'}
+
+        req = urllib.request.Request(url, headers=hdr) # What the program will use to request the url
+
         # Error handling
-        try: urllib.request.urlopen(url) # Tries to open the url
+        try: u = urllib.request.urlopen(req) # Tries to open the url, also assigns the variable if it passes
+        except urllib.error.HTTPError as e: # If the website returns an HTTP error, such as a 404, raise this error
+            print("The website you were requesting raised a " + str(e.code) + " - " + e.reason + " Error.") # e.code displays the error code, e.reason displays the reason for the code
+            quit()
         except urllib.error.URLError: # If the website does not exist, raise this error
             print("Error: This url does not exist.\n\tCheck the url and try again")
             quit()
         except ValueError: # If you did not add http or https, raise this error
             print("Error: You did not specify http or https\n\tAdd one and try again")
             quit()
-        else: # If website exists, do this and continue
-            u = urllib.request.urlopen(url, data=None)
+
+        # If website exists, continue
         file = io.TextIOWrapper(u, encoding='utf-8')
         file_contents = file.read()
     elif args.file:

--- a/the-streamliner.py
+++ b/the-streamliner.py
@@ -1,6 +1,6 @@
 #######################################
 #
-# The Streamliner v1.1.3
+# The Streamliner v1.1.4
 # Build By: Tobin Shields
 #           Twitter - @TobinShields
 #           Github  - https://github.com/TobinShields/
@@ -40,7 +40,7 @@ if not len(sys.argv) > 1:
   | | | '_ \ / _ \  `--. \ __| '__/ _ \/ _` | '_ ` _ \| | | '_ \ / _ \ '__|
   | | | | | |  __/ /\__/ / |_| | |  __/ (_| | | | | | | | | | | |  __/ |
   \_/ |_| |_|\___| \____/ \__|_|  \___|\__,_|_| |_| |_|_|_|_| |_|\___|_|
-                                                            Verion 1.1.3
+                                                            Verion 1.1.4
 
 Fork, Share, and Support this project on github:
 https://github.com/TobinShields/The_Streamliner

--- a/the-streamliner.py
+++ b/the-streamliner.py
@@ -76,12 +76,7 @@ else:
         # you couldn't get websites that don't have '.html' on the end.
         # But because of this, websites with invalid top level domain name
         # pass through the error filters, but this shouldn't happen in regular use.
-        hdr = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11',
-               'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-               'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
-               'Accept-Encoding': 'none',
-               'Accept-Language': 'en-US,en;q=0.8',
-               'Connection': 'keep-alive'}
+        hdr = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11'}
 
         req = urllib.request.Request(url, headers=hdr) # What the program will use to request the url
 


### PR DESCRIPTION
Added:
- Error handling for HTTP errors, such as 404 - Page Not Found errors

Fixed:
- Pages without `.html` raising a `URLError` fixed